### PR TITLE
Create frontend interface

### DIFF
--- a/quaqsim/api/_simulation_request.py
+++ b/quaqsim/api/_simulation_request.py
@@ -1,0 +1,32 @@
+from dataclasses import dataclass
+
+from ..program_ast.program import Program
+
+
+@dataclass
+class SimulationResult:
+    """Result of a simulation. The `pulse_schedule_graph` and `simulated_results_graph`
+    are base64-encoded PNGs."""
+    pulse_schedule_graph: str | None
+    simulated_results: list[list[float]] | None
+    simulated_results_graph: str | None
+    error: Exception | None
+
+
+@dataclass
+class SimulationRequest:
+    qua_configuration: dict | None = None
+    qua_program: Program | None = None
+    quantum_system: bytes | None = None
+    channel_map: bytes | None = None
+    result: SimulationResult | None = None
+
+    @property
+    def can_simulate(self) -> bool:
+        """Whether this request can be simulated."""
+        return (
+            self.qua_configuration is not None
+            and self.qua_program is not None
+            and self.quantum_system is not None
+            and self.channel_map is not None
+        )

--- a/quaqsim/api/backend.py
+++ b/quaqsim/api/backend.py
@@ -3,6 +3,7 @@ from typing import Annotated, Optional
 
 from fastapi import Body, FastAPI, HTTPException
 from fastapi import status as http_status
+from fastapi.middleware.wsgi import WSGIMiddleware
 import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
@@ -10,16 +11,16 @@ from qiskit.pulse import Schedule
 from qiskit.visualization.pulse_v2 import draw, IQXDebugging
 from qm.qua import *
 
-
+from ..architectures.transmon_pair_backend_from_qua import TransmonPairBackendFromQUA
 from ..program_to_quantum_pulse_sim_compiler.quantum_pulse_sim_compiler import Compiler
 from ._simulation_request import SimulationRequest, SimulationResult
+from .frontend import frontend
 from .utils import (
     load_from_base64,
     dump_fig_to_base64,
     program_to_ast,
     script_to_program,
 )
-from ..architectures.transmon_pair_backend_from_qua import TransmonPairBackendFromQUA
 
 matplotlib.use("agg")
 
@@ -73,6 +74,9 @@ def _get_simulated_results_graph(results):
 
 def create_app():
     app = FastAPI()
+
+    app.mount("/frontend", WSGIMiddleware(frontend.server))
+
     app.state.simulation_request = SimulationRequest()
 
     @app.post("/api/submit_qua_configuration")

--- a/quaqsim/api/backend.py
+++ b/quaqsim/api/backend.py
@@ -1,0 +1,188 @@
+from dataclasses import asdict
+from typing import Annotated, Optional
+
+from fastapi import Body, FastAPI, HTTPException
+from fastapi import status as http_status
+import matplotlib
+import matplotlib.pyplot as plt
+import numpy as np
+from qiskit.pulse import Schedule
+from qiskit.visualization.pulse_v2 import draw, IQXDebugging
+from qm.qua import *
+
+
+from ..program_to_quantum_pulse_sim_compiler.quantum_pulse_sim_compiler import Compiler
+from ._simulation_request import SimulationRequest, SimulationResult
+from .utils import (
+    load_from_base64,
+    dump_fig_to_base64,
+    program_to_ast,
+    script_to_program,
+)
+from ..architectures.transmon_pair_backend_from_qua import TransmonPairBackendFromQUA
+
+matplotlib.use("agg")
+
+
+def _get_pulse_schedule_graph(schedules: list[Schedule]):
+    n = len(schedules)
+    fig, ax = plt.subplots(
+        ncols=5,
+        nrows=n // 5 if n % 5 == 0 else n // 5 + 1,
+        figsize=(25, 4 * (n // 5)),
+        dpi=75,
+    )
+
+    for i, schedule in enumerate(schedules):
+        draw(
+            program=schedule,
+            style=IQXDebugging(),
+            backend=None,
+            time_range=None,
+            time_unit="ns",
+            disable_channels=None,
+            show_snapshot=True,
+            show_framechange=True,
+            show_waveform_info=True,
+            show_barrier=True,
+            plotter="mpl2d",
+            axis=ax[i // 5][i % 5],
+        )
+
+    fig.tight_layout()
+
+    return dump_fig_to_base64(fig)
+
+
+def _get_simulated_results_graph(results):
+    start, stop, step = -2, 2, 0.1
+
+    fig, ax = plt.subplots()
+    for i, result in enumerate(results):
+        ax.plot(
+            np.arange(start, stop, step),
+            result,
+            ".-",
+            label=f"Simulated Q{i}",
+        )
+        ax.set_ylim(-0.05, 1.05)
+    fig.legend()
+
+    return dump_fig_to_base64(fig)
+
+
+def create_app():
+    app = FastAPI()
+    app.state.simulation_request = SimulationRequest()
+
+    @app.post("/api/submit_qua_configuration")
+    async def submit_qua_configuration(
+        qua_configuration: Annotated[str, Body(embed=True)],
+    ):
+        """Submit QUA configuration. The dict must be serialized with dill and encoded
+        as a base64 string."""
+        app.state.simulation_request.qua_configuration = load_from_base64(
+            qua_configuration
+        )
+
+    @app.post("/api/submit_qua_program")
+    async def submit_qua_program(
+        qua_script: Annotated[Optional[str], Body(embed=True)] = None,
+        qua_program: Annotated[Optional[str], Body(embed=True)] = None,
+    ):
+        """Submit QUA script or program. The string or program_ast.Program must be
+        serialized with dill and encoded as a base64 string.
+
+        Warning:
+            If provided, `qua_script` is executed through `exec()`, which is a security
+            risk if the input is not trusted.
+        """
+        if qua_script is not None and qua_program is not None:
+            raise ValueError(
+                "Only one of `qua_script` and `qua_program` can be provided"
+            )
+
+        if qua_script is not None:
+            app.state.simulation_request.qua_program = program_to_ast(
+                script_to_program(load_from_base64(qua_script))
+            )
+        elif qua_program is not None:
+            app.state.simulation_request.qua_program = load_from_base64(qua_program)
+        else:
+            raise ValueError("One of `qua_script` and `qua_program` must be provided")
+
+    @app.post("/api/submit_quantum_system")
+    async def submit_quantum_system(quantum_system: Annotated[bytes, Body(embed=True)]):
+        """Submit quantum system. The object must be serialized with dill and encoded as
+        a base64 string."""
+        app.state.simulation_request.quantum_system = load_from_base64(quantum_system)
+
+    @app.post("/api/submit_channel_map")
+    async def submit_channel_map(channel_map: Annotated[bytes, Body(embed=True)]):
+        """Submit quantum system. The dict must be serialized with dill and encoded as a
+        base64 string."""
+        app.state.simulation_request.channel_map = load_from_base64(channel_map)
+
+    @app.get("/api/simulate")
+    async def simulate(num_shots: int = 1000):
+        """Simulate the system."""
+        # When this method returns, `self.result` is set.
+        request: SimulationRequest = app.state.simulation_request
+
+        try:
+            if not request.can_simulate:
+                raise ValueError("Missing data for simulation.")
+
+            # This is a breakdown of `simulate_program`, which gives an easier access to
+            # the schedules in `simulation`.
+            compiler = Compiler(config=request.qua_configuration)
+            simulation = compiler.compile(
+                request.qua_program,
+                request.channel_map,
+                TransmonPairBackendFromQUA(request.quantum_system, request.channel_map),
+            )
+            results = simulation.run(num_shots)
+        except Exception as e:
+            request.result = SimulationResult(
+                pulse_schedule_graph=None,
+                simulated_results=None,
+                simulated_results_graph=None,
+                error=e,
+            )
+        else:
+            request.result = SimulationResult(
+                pulse_schedule_graph=_get_pulse_schedule_graph(simulation.schedules),
+                simulated_results=results,
+                simulated_results_graph=_get_simulated_results_graph(results),
+                error=None,
+            )
+
+    @app.get("/api/status")
+    async def status() -> dict:
+        """Return a dict with the result of the simulation, or an HTTP error if
+        something went wrong."""
+        result: SimulationResult = app.state.simulation_request.result
+
+        if result is None:
+            raise HTTPException(
+                status_code=http_status.HTTP_400_BAD_REQUEST,
+                detail="/simulate was not called",
+            )
+
+        if result.error is not None:
+            raise HTTPException(
+                status_code=http_status.HTTP_400_BAD_REQUEST,
+                detail=str(app.state.simulation_request.result.error),
+            )
+
+        return asdict(result)
+
+    @app.post("/api/reset")
+    async def reset():
+        """Erase any request and simulation."""
+        app.state.simulation_request = SimulationRequest()
+
+    return app
+
+
+app = create_app()

--- a/quaqsim/api/frontend.py
+++ b/quaqsim/api/frontend.py
@@ -1,0 +1,131 @@
+import dash_bootstrap_components as dbc
+from dash import Dash, html, callback, Input, Output, ctx
+import requests
+
+
+frontend = Dash(
+    __name__,
+    external_stylesheets=[dbc.themes.BOOTSTRAP],
+    requests_pathname_prefix="/frontend/",
+)
+
+controls = html.Div(
+    [
+        dbc.Button("Reload", color="primary", id="reload", class_name="me-3"),
+        dbc.Button("Reset", outline=True, color="danger", id="reset"),
+    ]
+)
+
+frontend.layout = dbc.Container(
+    [
+        html.H1("qua-qsim frontend"),
+        html.Hr(),
+        dbc.Row(
+            dbc.Col(
+                controls,
+            ),
+        ),
+        dbc.Row(
+            dbc.Col(
+                html.Div("Message", id="message"),
+            ),
+            class_name="mt-3",
+            id="message-row",
+            style={"display": "none"},
+        ),
+        html.H2("Pulse schedule", className="mt-3"),
+        html.Hr(),
+        dbc.Row(
+            dbc.Col(
+                html.Img(id="pulse-schedule"),
+                width=6,
+            ),
+            class_name="mt-3",
+            id="pulse-schedule-row",
+            style={"display": "none"},
+        ),
+        html.H2("Simulated results", className="mt-3"),
+        html.Hr(),
+        dbc.Row(
+            dbc.Col(
+                html.Img(id="simulated-results"),
+                width=6,
+            ),
+            class_name="mt-3",
+            id="simulated-results-row",
+            style={"display": "none"},
+        ),
+    ],
+    fluid=True,
+)
+
+
+@callback(
+    [
+        Output("message", "children"),
+        Output("message-row", "style"),
+        Output("pulse-schedule", "src"),
+        Output("pulse-schedule-row", "style"),
+        Output("simulated-results", "src"),
+        Output("simulated-results-row", "style"),
+    ],
+    Input("reload", "n_clicks"),
+    Input("reset", "n_clicks"),
+    prevent_initial_call=True,
+)
+def update_simulated_results(reload, reset):
+    triggered_id = ctx.triggered_id
+
+    if triggered_id == "reload":
+        return _reload_simulated_results()
+    elif triggered_id == "reset":
+        return _reset_simulated_results()
+
+
+def _reload_simulated_results():
+    response = requests.get("http://localhost:8000/api/status")
+
+    if response.status_code == 200:
+        pulse_schedule_graph = response.json()["pulse_schedule_graph"]
+        simulated_results_graph = response.json()["simulated_results_graph"]
+        return (
+            "",
+            {"display": "none"},
+            f"data:image/png;base64,{pulse_schedule_graph}",
+            {"display": "block"},
+            f"data:image/png;base64,{simulated_results_graph}",
+            {"display": "block"},
+        )
+    else:
+        error_message = response.json()["detail"]
+        return (
+            f"Error: “{error_message}”.",
+            {"display": "block"},
+            "",
+            {"display": "none"},
+            "",
+            {"display": "none"},
+        )
+
+
+def _reset_simulated_results():
+    response = requests.post("http://localhost:8000/api/reset")
+
+    if response.status_code == 200:
+        return (
+            "Simulation was reset successfully.",
+            {"display": "block"},
+            "",
+            {"display": "none"},
+            "",
+            {"display": "none"},
+        )
+
+    return (
+        f"Error: {response.text}.",
+        {"display": "block"},
+        "",
+        {"display": "none"},
+        "",
+        {"display": "none"},
+    )

--- a/quaqsim/api/utils.py
+++ b/quaqsim/api/utils.py
@@ -1,0 +1,44 @@
+import base64
+import dill
+
+from io import BytesIO
+from typing import Any
+
+from qm import Program
+from qm.qua import *  # Useful to `script_to_program`.
+
+from ..program_ast.program import Program as ProgramAST
+from ..program_dict_to_program_compiler.program_tree_builder import ProgramTreeBuilder
+
+
+def load_from_base64(s: str) -> Any:
+    """Deserialize an object serialized as a base 64 string."""
+    return dill.loads(base64.b64decode(s))
+
+
+def dump_to_base64(obj: Any) -> str:
+    """Serialize an object into a base 64 string."""
+    return base64.b64encode(dill.dumps(obj)).decode(encoding="utf-8")
+
+
+def dump_fig_to_base64(fig) -> str:
+    """Serialize a matplotlib figure into a base 64 string."""
+    buffer = BytesIO()
+    fig.savefig(buffer, format="png")
+    buffer.seek(0)
+    return base64.b64encode(buffer.getvalue()).decode(encoding="utf-8")
+
+
+def script_to_program(script: str) -> Program:
+    """Convert a QUA script into a QM Program.
+
+    This is a security concern if `script` is not trusted.
+    """
+    with program() as prog:
+        exec(script)
+    return prog
+
+
+def program_to_ast(prog: Program) -> ProgramAST:
+    """Transform a QM Program into an AST, which is safer to serialize."""
+    return ProgramTreeBuilder().build(prog)

--- a/quaqsim/program_to_quantum_pulse_sim_compiler/quantum_pulse_sim_compiler.py
+++ b/quaqsim/program_to_quantum_pulse_sim_compiler/quantum_pulse_sim_compiler.py
@@ -5,6 +5,7 @@ from .program_to_timelines_compiler import ProgramToTimelinesCompiler
 from .quantum_pulse_sim import QuantumPulseSimulator
 from .timeline_to_schedule_compiler import TimelineToPulseScheduleCompiler
 from ..architectures.transmon_pair_backend_from_qua import ConfigToTransmonPairBackendMap
+from ..program_ast.program import Program as ProgramAST
 from ..program_dict_to_program_compiler.program_tree_builder import ProgramTreeBuilder
 
 
@@ -13,12 +14,16 @@ class Compiler:
         self.config = config
 
     def compile(self,
-                program: qm.Program,
+                program: qm.Program | ProgramAST,
                 channel_map: ConfigToTransmonPairBackendMap,
                 backend: DynamicsBackend) -> QuantumPulseSimulator:
 
-        # Compile raw program dictionary into an abstract syntax tree
-        program_tree = ProgramTreeBuilder().build(program)
+        # If program is a qm.Program, and not directly an AST, compile it into an AST
+        program_tree = (
+            program
+            if isinstance(program, ProgramAST)
+            else ProgramTreeBuilder().build(program)
+        )
 
         # Compile the abstract syntax tree into an intermediate, pulse timeline representation
         timelines = ProgramToTimelinesCompiler().compile(self.config, program_tree, channel_map)

--- a/quaqsim/simulate.py
+++ b/quaqsim/simulate.py
@@ -5,9 +5,10 @@ from qm import Program
 
 from quaqsim import Compiler
 from quaqsim.architectures.transmon_pair_backend_from_qua import ConfigToTransmonPairBackendMap
+from quaqsim.program_ast.program import Program as ProgramAST
 
 
-def simulate_program(qua_program: Program,
+def simulate_program(qua_program: Program | ProgramAST,
                      qua_config: dict,
                      qua_config_to_backend_map: ConfigToTransmonPairBackendMap,
                      backend: DynamicsBackend,

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ qm-qua
 dataclasses_json
 jax
 jaxlib
+fastapi
+uvicorn

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,6 @@ jax
 jaxlib
 fastapi
 uvicorn
+dash
+dash_bootstrap_components
+requests

--- a/test/api/test_backend.py
+++ b/test/api/test_backend.py
@@ -1,0 +1,127 @@
+import numpy as np
+import pytest
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from quaqsim.api.backend import create_app
+from quaqsim.api.utils import dump_to_base64, program_to_ast
+
+
+@pytest.fixture
+def app() -> FastAPI:
+    return create_app()
+
+
+@pytest.fixture
+def client(app: FastAPI) -> TestClient:
+    return TestClient(app)
+
+
+def test_submit_qua_configuration(client: TestClient, transmon_pair_qua_config: dict):
+    response = client.post(
+        "/api/submit_qua_configuration",
+        json={"qua_configuration": dump_to_base64(transmon_pair_qua_config)},
+    )
+    assert response.json() is None
+    assert response.status_code == 200
+
+
+def test_submit_qua_script(client: TestClient, rabi_prog_script):
+    response = client.post(
+        "/api/submit_qua_program",
+        json={"qua_script": dump_to_base64(rabi_prog_script)},
+    )
+    assert response.json() is None
+    assert response.status_code == 200
+
+
+def test_submit_qua_program(client: TestClient, rabi_prog):
+    response = client.post(
+        "/api/submit_qua_program",
+        json={"qua_program": dump_to_base64(program_to_ast(rabi_prog))},
+    )
+    assert response.json() is None
+    assert response.status_code == 200
+
+
+def test_submit_quantum_system(client: TestClient, transmon_pair):
+    response = client.post(
+        "/api/submit_quantum_system",
+        json={"quantum_system": dump_to_base64(transmon_pair)},
+    )
+    assert response.json() is None
+    assert response.status_code == 200
+
+
+def test_submit_channel_map(client: TestClient, config_to_transmon_pair_backend_map):
+    response = client.post(
+        "/api/submit_channel_map",
+        json={"channel_map": dump_to_base64(config_to_transmon_pair_backend_map)},
+    )
+    assert response.json() is None
+    assert response.status_code == 200
+
+
+@pytest.fixture
+def submit_rabi(
+    client: TestClient,
+    transmon_pair_qua_config,
+    rabi_prog,
+    transmon_pair,
+    config_to_transmon_pair_backend_map,
+):
+    client.post(
+        "/api/submit_qua_configuration",
+        json={"qua_configuration": dump_to_base64(transmon_pair_qua_config)},
+    )
+    client.post(
+        "/api/submit_qua_program",
+        json={"qua_program": dump_to_base64(program_to_ast(rabi_prog))},
+    )
+    client.post(
+        "/api/submit_quantum_system",
+        json={"quantum_system": dump_to_base64(transmon_pair)},
+    )
+    client.post(
+        "/api/submit_channel_map",
+        json={"channel_map": dump_to_base64(config_to_transmon_pair_backend_map)},
+    )
+
+
+def test_status_no_simulate(client: TestClient, submit_rabi):
+    response = client.get("/api/status")
+    assert response.status_code == 400
+    assert response.json() == {"detail": "/simulate was not called"}
+
+
+def test_status_simulate_missing_data(client: TestClient, transmon_pair_qua_config):
+    client.post(
+        "/api/submit_qua_configuration",
+        json={"qua_configuration": transmon_pair_qua_config},
+    )
+    client.get("/api/simulate")
+
+    response = client.get("/api/status")
+    assert response.status_code == 400
+    assert response.json() == {"detail": "Missing data for simulation."}
+
+
+def test_status(client: TestClient, submit_rabi):
+    client.get("/api/simulate")
+
+    response = client.get("/api/status")
+    assert response.status_code == 200
+
+    data = response.json()
+    assert "pulse_schedule_graph" in data
+    assert "simulated_results_graph" in data
+
+    results = data["simulated_results"]
+    start, stop, step = -2, 2, 0.1
+    q1_state_probabilities = np.array(results[0])
+    q2_state_probabilities = np.array(results[0])
+    amps = np.arange(start, stop, step)
+    expected_state_probabilities = np.sin(np.pi * amps / 4) ** 2
+    assert np.allclose(q1_state_probabilities, expected_state_probabilities, atol=0.1)
+    assert np.allclose(q2_state_probabilities, expected_state_probabilities, atol=0.1)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,5 +1,7 @@
 import pytest
 
+from qm.qua import *
+
 from quaqsim.architectures import TransmonSettings
 from quaqsim.architectures.transmon import Transmon
 from quaqsim.architectures.transmon_pair import TransmonPair
@@ -285,3 +287,34 @@ def transmon_pair_qua_config(transmon_pair) -> dict:
         },
     }
 
+
+@pytest.fixture
+def rabi_prog():
+    with program() as prog:
+        start, stop, step = -2, 2, 0.1
+        a = declare(fixed)
+
+        with for_(a, start, a < stop - 0.0001, a + step):
+            play("x90"*amp(a), "qubit_1")
+            play("x90"*amp(a), "qubit_2")
+
+            align("qubit_1", "qubit_2", "resonator_1", "resonator_2")
+            measure("readout", "resonator_1", None)
+            measure("readout", "resonator_2", None)
+
+    return prog
+
+
+@pytest.fixture
+def rabi_prog_script(rabi_prog) -> str:
+    return '''
+start, stop, step = -2, 2, 0.1
+a = declare(fixed)
+
+with for_(a, start, a < stop - 0.0001, a + step):
+    play("x90"*amp(a), "qubit_1")
+    play("x90"*amp(a), "qubit_2")
+
+    align("qubit_1", "qubit_2", "resonator_1", "resonator_2")
+    measure("readout", "resonator_1", None)
+    measure("readout", "resonator_2", None)'''.strip()


### PR DESCRIPTION
Closes: #4 (as part of unitaryHACK 2024)

Implement a FastAPI backend and a Dash frontend (http://127.0.0.1:8000/frontend/) to visualize the simulated results and the Qiskit Pulse Schedule of a QUA program.

Requirements in #4 are respected. One non-trivial issue remains: the code for plotting the simulated results is not transmitted through the API, so it has to be the same for all programs, which is obviously not possible. I'm not sure about what would be the best here (the current implementation uses the plotting code of `test_rabi.py`).

Run `uvicorn quaqsim.api.backend:app`, run `_main.py` and go to http://127.0.0.1:8000/frontend/ to test.

Note: `_main.py` is included in this PR temporarily, as a way to quickly test the API.

![image](https://github.com/qua-platform/qua-qsim/assets/11032610/52628f43-687d-4a76-87f4-86da3ac2f1d4)
